### PR TITLE
convert azure Matrix to map[string]any instead of map[string]map[string]string

### DIFF
--- a/pkg/loaders/azure/azure_test.go
+++ b/pkg/loaders/azure/azure_test.go
@@ -348,7 +348,14 @@ func TestLoad(t *testing.T) {
 									},
 								},
 							},
-							FileReference: testutils.CreateFileReference(4, 3, 12, 30),
+							Strategy: &models.JobStrategy{
+								MaxParallel: 2,
+								Matrix: &models.Matrix{
+									"${{ if in(parameters.artifactType,'*', 'docker/image') }}": map[string]any{"docker": map[string]string{"ArtifactType": "docker/image"}},
+									"${{ if in(parameters.artifactType,'*', 'docker/tar') }}":   map[string]any{"tar": "tar"},
+								},
+							},
+							FileReference: testutils.CreateFileReference(4, 3, 20, 19),
 						},
 					},
 					DeploymentJobs: []*models.DeploymentJob{
@@ -359,14 +366,14 @@ func TestLoad(t *testing.T) {
 								DependsOn:   &models.DependsOn{"job1", "job2"},
 								Pool: &models.Pool{
 									VmImage:       "ubuntu-latest",
-									FileReference: testutils.CreateFileReference(16, 5, 17, 27),
+									FileReference: testutils.CreateFileReference(24, 5, 25, 27),
 								},
 							},
 							Environment: &models.DeploymentEnvironmentRef{
 								DeploymentEnvironment: &models.DeploymentEnvironment{
 									Name: "smarthotel-dev",
 								},
-								FileReference: testutils.CreateFileReference(19, 16, 19, 30),
+								FileReference: testutils.CreateFileReference(27, 16, 27, 30),
 							},
 							Strategy: &models.DeploymentStrategy{
 								RunOnce: &models.BaseDeploymentStrategy{
@@ -380,7 +387,7 @@ func TestLoad(t *testing.T) {
 									},
 								},
 							},
-							FileReference: testutils.CreateFileReference(13, 3, 25, 43),
+							FileReference: testutils.CreateFileReference(21, 3, 33, 43),
 						},
 					},
 					TemplateJobs: []*models.TemplateJob{
@@ -394,7 +401,7 @@ func TestLoad(t *testing.T) {
 									},
 								},
 							},
-							FileReference: testutils.CreateFileReference(26, 3, 30, 28),
+							FileReference: testutils.CreateFileReference(34, 3, 38, 28),
 						},
 						{
 							Template: models.Template{
@@ -406,7 +413,7 @@ func TestLoad(t *testing.T) {
 									},
 								},
 							},
-							FileReference: testutils.CreateFileReference(32, 3, 36, 29),
+							FileReference: testutils.CreateFileReference(40, 3, 44, 29),
 						},
 						{
 							Template: models.Template{
@@ -419,10 +426,10 @@ func TestLoad(t *testing.T) {
 									"sign": true,
 								},
 							},
-							FileReference: testutils.CreateFileReference(37, 3, 42, 15),
+							FileReference: testutils.CreateFileReference(45, 3, 46, 15),
 						},
 					},
-					FileReference: testutils.CreateFileReference(3, -1, 42, 15),
+					FileReference: testutils.CreateFileReference(3, -1, 50, 15),
 				},
 			},
 		},

--- a/pkg/loaders/azure/models/strategy.go
+++ b/pkg/loaders/azure/models/strategy.go
@@ -1,6 +1,6 @@
 package models
 
-type Matrix map[string]map[string]string
+type Matrix map[string]any
 
 type JobStrategy struct {
 	Matrix      *Matrix `yaml:"matrix,omitempty"`

--- a/test/blackbox/azure_test.go
+++ b/test/blackbox/azure_test.go
@@ -126,7 +126,7 @@ func TestAzure(t *testing.T) {
 							{JobID: utils.GetPtr("job1")},
 							{JobID: utils.GetPtr("job2")},
 						},
-						FileReference: testutils.CreateFileReference(13, 3, 25, 43),
+						FileReference: testutils.CreateFileReference(21, 3, 33, 43),
 					},
 					{
 						ID:              utils.GetPtr("MyJob"),
@@ -151,7 +151,7 @@ func TestAzure(t *testing.T) {
 								FileReference: testutils.CreateFileReference(12, 5, 12, 30),
 							},
 						},
-						FileReference: testutils.CreateFileReference(4, 3, 12, 30),
+						FileReference: testutils.CreateFileReference(4, 3, 20, 19),
 					},
 				},
 			},

--- a/test/fixtures/azure/jobs.yaml
+++ b/test/fixtures/azure/jobs.yaml
@@ -10,6 +10,14 @@ jobs:
     clean: outputs
   steps:
   - script: echo My first job
+  strategy:
+      maxParallel: 2
+      matrix:
+        ${{ if in(parameters.artifactType,'*', 'docker/image') }}:
+          docker:
+            ArtifactType: docker/image
+        ${{ if in(parameters.artifactType,'*', 'docker/tar') }}:
+          tar: tar
 - deployment: DeployWeb
   displayName: deploy Web App
   dependsOn: [job1, job2]


### PR DESCRIPTION
## Description
Fixed azure loader bug - could not handle with matrix inside a job

## Related issues
- Close #44 

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/argonsecurity/pipeline-parser/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've followed the [conventions](https://github.com/argonsecurity/pipeline-parser/blob/main/CONTRIBUTING.md#pull-requests) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [readme](https://github.com/argonsecurity/pipeline-parser/blob/main/README.md) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).