### PR TITLE
make azure step enabled string instead of boolean

### DIFF
--- a/pkg/consts/bool.go
+++ b/pkg/consts/bool.go
@@ -1,0 +1,4 @@
+package consts
+
+var TrueValues = []string{"true", "on", "y", "yes"}
+var FalseValues = []string{"false", "off", "n", "no"}

--- a/pkg/loaders/azure/models/step.go
+++ b/pkg/loaders/azure/models/step.go
@@ -25,7 +25,7 @@ type Step struct {
 	ContinueOnError         *bool                    `yaml:"continueOnError,omitempty"`
 	DisplayName             string                   `yaml:"displayName,omitempty"`
 	Target                  *StepTarget              `yaml:"target,omitempty"`
-	Enabled                 *bool                    `yaml:"enabled,omitempty"`
+	Enabled                 *string                  `yaml:"enabled,omitempty"`
 	Env                     *EnvironmentVariablesRef `yaml:"env,omitempty"`
 	TimeoutInMinutes        int                      `yaml:"timeoutInMinutes,omitempty"`
 	RetryCountOnTaskFailure int                      `yaml:"retryCountOnTaskFailure,omitempty"`

--- a/pkg/parsers/azure/steps.go
+++ b/pkg/parsers/azure/steps.go
@@ -3,11 +3,13 @@ package azure
 import (
 	"strings"
 
+	"github.com/argonsecurity/pipeline-parser/pkg/consts"
 	azureModels "github.com/argonsecurity/pipeline-parser/pkg/loaders/azure/models"
 	loadersCommonModels "github.com/argonsecurity/pipeline-parser/pkg/loaders/common/models"
 	"github.com/argonsecurity/pipeline-parser/pkg/models"
 	parserUtils "github.com/argonsecurity/pipeline-parser/pkg/parsers/utils"
 	"github.com/argonsecurity/pipeline-parser/pkg/utils"
+	"golang.org/x/exp/slices"
 )
 
 func parseSteps(steps *azureModels.Steps) []*models.Step {
@@ -66,7 +68,7 @@ func parseStep(step azureModels.Step) *models.Step {
 	}
 
 	if step.Enabled != nil {
-		parsedStep.Disabled = utils.GetPtr(!*step.Enabled)
+		parsedStep.Disabled = utils.GetPtr(!slices.Contains(consts.TrueValues, *step.Enabled))
 	}
 
 	return parsedStep

--- a/pkg/parsers/azure/steps_test.go
+++ b/pkg/parsers/azure/steps_test.go
@@ -201,7 +201,7 @@ func TestParseStep(t *testing.T) {
 				TimeoutInMinutes: 1,
 				WorkingDirectory: "dir",
 				Script:           "script",
-				Enabled:          utils.GetPtr(true),
+				Enabled:          utils.GetPtr("true"),
 			},
 			expectedStep: &models.Step{
 				ID:   utils.GetPtr("1"),
@@ -242,7 +242,7 @@ func TestParseStep(t *testing.T) {
 				TimeoutInMinutes: 1,
 				WorkingDirectory: "dir",
 				Bash:             "script",
-				Enabled:          utils.GetPtr(true),
+				Enabled:          utils.GetPtr("true"),
 			},
 			expectedStep: &models.Step{
 				ID:   utils.GetPtr("1"),
@@ -283,7 +283,7 @@ func TestParseStep(t *testing.T) {
 				TimeoutInMinutes: 1,
 				WorkingDirectory: "dir",
 				Powershell:       "script",
-				Enabled:          utils.GetPtr(true),
+				Enabled:          utils.GetPtr("true"),
 			},
 			expectedStep: &models.Step{
 				ID:   utils.GetPtr("1"),
@@ -324,7 +324,7 @@ func TestParseStep(t *testing.T) {
 				TimeoutInMinutes: 1,
 				WorkingDirectory: "dir",
 				Pwsh:             "script",
-				Enabled:          utils.GetPtr(true),
+				Enabled:          utils.GetPtr("true"),
 			},
 			expectedStep: &models.Step{
 				ID:   utils.GetPtr("1"),


### PR DESCRIPTION
## Description
make azure step enabled string instead of boolean

## Related issues
- Close #47 

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/argonsecurity/pipeline-parser/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've followed the [conventions](https://github.com/argonsecurity/pipeline-parser/blob/main/CONTRIBUTING.md#pull-requests) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [readme](https://github.com/argonsecurity/pipeline-parser/blob/main/README.md) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).