### PR TITLE
Fixed a bug, treating azure maxParallel key as an int instead of a string

### DIFF
--- a/pkg/loaders/azure/azure_test.go
+++ b/pkg/loaders/azure/azure_test.go
@@ -349,7 +349,7 @@ func TestLoad(t *testing.T) {
 								},
 							},
 							Strategy: &models.JobStrategy{
-								MaxParallel: 2,
+								MaxParallel: "2",
 								Matrix: &models.Matrix{
 									"${{ if in(parameters.artifactType,'*', 'docker/image') }}": map[string]any{"docker": map[string]string{"ArtifactType": "docker/image"}},
 									"${{ if in(parameters.artifactType,'*', 'docker/tar') }}":   map[string]any{"tar": "tar"},

--- a/pkg/loaders/azure/models/strategy.go
+++ b/pkg/loaders/azure/models/strategy.go
@@ -4,7 +4,7 @@ type Matrix map[string]any
 
 type JobStrategy struct {
 	Matrix      *Matrix `yaml:"matrix,omitempty"`
-	MaxParallel int     `yaml:"maxParallel,omitempty"`
+	MaxParallel string  `yaml:"maxParallel,omitempty"`
 	Parallel    string  `yaml:"parallel,omitempty"`
 }
 


### PR DESCRIPTION
## Description
Change Azure `job.strategy.maxParallel` key to be a string and not an int

## Related issues
- Close #52 


## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/argonsecurity/pipeline-parser/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've followed the [conventions](https://github.com/argonsecurity/pipeline-parser/blob/main/CONTRIBUTING.md#pull-requests) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [readme](https://github.com/argonsecurity/pipeline-parser/blob/main/README.md) with the relevant information (if needed).