### PR TITLE
GitLab - Support imported pipelines

### DIFF
--- a/pkg/enhancers/github/github.go
+++ b/pkg/enhancers/github/github.go
@@ -3,19 +3,17 @@ package github
 import (
 	"github.com/argonsecurity/pipeline-parser/pkg/enhancers"
 	"github.com/argonsecurity/pipeline-parser/pkg/models"
-	"github.com/pkg/errors"
 )
 
 type GitHubEnhancer struct{}
 
 func (g *GitHubEnhancer) LoadImportedPipelines(data *models.Pipeline, credentials *models.Credentials) ([]*enhancers.ImportedPipeline, error) {
-	var errs error
 	importedPipelines, err := getReusableWorkflows(data, credentials)
 	if err != nil {
-		errs = errors.Wrap(errs, err.Error())
+		return importedPipelines, err
 	}
 
-	return importedPipelines, errs
+	return importedPipelines, nil
 }
 
 func (g *GitHubEnhancer) Enhance(data *models.Pipeline, importedPipelines []*enhancers.ImportedPipeline) (*models.Pipeline, error) {

--- a/pkg/enhancers/github/reusable_workflows.go
+++ b/pkg/enhancers/github/reusable_workflows.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/argonsecurity/pipeline-parser/pkg/enhancers"
 	"github.com/argonsecurity/pipeline-parser/pkg/models"
-	"github.com/imroc/req/v3"
+	"github.com/argonsecurity/pipeline-parser/pkg/utils"
 )
 
 var (
@@ -60,7 +60,7 @@ func loadRemoteFile(org, repo, version, path string, credentials *models.Credent
 	}
 
 	url := fmt.Sprintf("%s/%s/%s/%s/%s", GithubBaseURL, org, repo, version, path)
-	client := getHttpClient(credentials)
+	client := utils.GetHttpClient(credentials)
 	resp, err := client.R().Get(url)
 	if err != nil {
 		return nil, err
@@ -89,14 +89,4 @@ func loadLocalFile(path string) ([]byte, error) {
 	}
 
 	return buf, nil
-}
-
-func getHttpClient(credentials *models.Credentials) *req.Client {
-	client := req.C()
-	if credentials == nil {
-		return client
-	}
-
-	return client.SetCommonHeader("Authorization", fmt.Sprintf("token %s", credentials.Token))
-
 }

--- a/pkg/enhancers/github/reusable_workflows.go
+++ b/pkg/enhancers/github/reusable_workflows.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	GithubBaseURL = "https://raw.githubusercontent.com"
+	GITHUB_BASE_URL = "https://raw.githubusercontent.com"
 )
 
 func getReusableWorkflows(pipeline *models.Pipeline, credentials *models.Credentials) ([]*enhancers.ImportedPipeline, error) {
@@ -62,7 +62,7 @@ func loadRemoteFile(org, repo, version, path string, credentials *models.Credent
 		version = "main"
 	}
 
-	url := fmt.Sprintf("%s/%s/%s/%s/%s", GithubBaseURL, org, repo, version, path)
+	url := fmt.Sprintf("%s/%s/%s/%s/%s", GITHUB_BASE_URL, org, repo, version, path)
 	client := utils.GetHttpClient(credentials)
 	resp, err := client.R().Get(url)
 	if err != nil {

--- a/pkg/enhancers/github/reusable_workflows.go
+++ b/pkg/enhancers/github/reusable_workflows.go
@@ -22,6 +22,9 @@ func getReusableWorkflows(pipeline *models.Pipeline, credentials *models.Credent
 		if job.Imports != nil {
 			importedPipelineBuf, err := handleImport(job.Imports, credentials)
 			if err != nil {
+				if errs == nil {
+					errs = errors.New("got error(s) importing pipeline(s):")
+				}
 				errs = errors.Wrap(errs, fmt.Sprintf("error importing pipeline for job %s: %s", *job.Name, err.Error()))
 			}
 			importedPipelines = append(importedPipelines, &enhancers.ImportedPipeline{

--- a/pkg/enhancers/github/reusable_workflows_test.go
+++ b/pkg/enhancers/github/reusable_workflows_test.go
@@ -101,6 +101,7 @@ func Test_getReusableWorkflows(t *testing.T) {
 					Data:    nil,
 				},
 			},
+			wantErr: true,
 		},
 		{
 			name: "remote does not exist",
@@ -141,6 +142,7 @@ func Test_getReusableWorkflows(t *testing.T) {
 					Data:    []byte("file data"),
 				},
 			},
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/enhancers/github/reusable_workflows_test.go
+++ b/pkg/enhancers/github/reusable_workflows_test.go
@@ -147,7 +147,7 @@ func Test_getReusableWorkflows(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := http.FileServer(http.Dir("testdata"))
 			ts := httptest.NewServer(h)
-			GithubBaseURL = ts.URL
+			GITHUB_BASE_URL = ts.URL
 
 			got, err := getReusableWorkflows(tt.args.pipeline, tt.args.credentials)
 
@@ -297,7 +297,7 @@ func Test_handleImport(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := http.FileServer(http.Dir("testdata"))
 			ts := httptest.NewServer(h)
-			GithubBaseURL = ts.URL
+			GITHUB_BASE_URL = ts.URL
 
 			got, err := handleImport(tt.args.imports, tt.args.credentials)
 
@@ -368,7 +368,7 @@ func Test_loadRemoteFile(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := http.FileServer(http.Dir("testdata"))
 			ts := httptest.NewServer(h)
-			GithubBaseURL = ts.URL
+			GITHUB_BASE_URL = ts.URL
 
 			got, err := loadRemoteFile(tt.args.org, tt.args.repo, tt.args.version, tt.args.path, tt.args.credentials)
 

--- a/pkg/enhancers/gitlab/gitlab.go
+++ b/pkg/enhancers/gitlab/gitlab.go
@@ -1,16 +1,105 @@
 package gitlab
 
 import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/pkg/errors"
+
 	"github.com/argonsecurity/pipeline-parser/pkg/enhancers"
 	"github.com/argonsecurity/pipeline-parser/pkg/models"
+	"github.com/argonsecurity/pipeline-parser/pkg/utils"
+)
+
+var (
+	GITLAB_BASE_URL = "https://gitlab.com"
 )
 
 type GitLabEnhancer struct{}
 
 func (g *GitLabEnhancer) LoadImportedPipelines(data *models.Pipeline, credentials *models.Credentials) ([]*enhancers.ImportedPipeline, error) {
+	var errs error
+	importedPipelines := []*enhancers.ImportedPipeline{}
+	if data.Imports != nil {
+		for _, importData := range data.Imports {
+			importedPipeline, err := handleImport(importData, credentials)
+			if err != nil {
+				errs = errors.Wrap(errs, fmt.Sprintf("error importing pipeline: %s", err.Error()))
+			}
+			importedPipelines = append(importedPipelines, importedPipeline)
+		}
+	}
+	return importedPipelines, errs
+}
+
+func handleImport(importData *models.Import, credentials *models.Credentials) (*enhancers.ImportedPipeline, error) {
+	if importData == nil || importData.Source == nil {
+		return nil, nil
+	}
+
+	if importData.Source.Type == models.SourceTypeRemote {
+		return handleRemoteImport(importData, credentials)
+	}
+
+	if importData.Source.Type == models.SourceTypeLocal {
+		return handleLocalImport(importData)
+	}
+
 	return nil, nil
 }
 
+func handleRemoteImport(importData *models.Import, credentials *models.Credentials) (*enhancers.ImportedPipeline, error) {
+	if importData.Source.Type != models.SourceTypeRemote {
+		return nil, errors.New("invalid source type for remote import")
+	}
+
+	if importData.Source.Organization == nil ||
+		importData.Source.Repository == nil ||
+		importData.Source.Path == nil ||
+		importData.Version == nil {
+		return nil, errors.New("missing required fields for remote import")
+	}
+
+	url := fmt.Sprintf("%s/%s/%s/-/raw/%s/%s",
+		GITLAB_BASE_URL,
+		*importData.Source.Organization,
+		*importData.Source.Repository,
+		*importData.Version,
+		*importData.Source.Path,
+	)
+	client := utils.GetHttpClient(credentials)
+	resp, err := client.R().Get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.IsErrorState() {
+		return nil, errors.New(resp.Response.Status)
+	}
+
+	buf := resp.Bytes()
+	return &enhancers.ImportedPipeline{Data: buf}, nil
+}
+
+func handleLocalImport(importData *models.Import) (*enhancers.ImportedPipeline, error) {
+	buf, err := os.ReadFile(strings.TrimPrefix(*importData.Source.Path, "/"))
+	if err != nil {
+		return nil, err
+	}
+
+	return &enhancers.ImportedPipeline{
+		Data: buf,
+	}, nil
+}
+
 func (g *GitLabEnhancer) Enhance(data *models.Pipeline, importedPipelines []*enhancers.ImportedPipeline) (*models.Pipeline, error) {
+	for i, importData := range data.Imports {
+		importedPipeline := importedPipelines[i]
+		if importedPipeline != nil {
+			importData.Pipeline = importedPipeline.Pipeline
+		}
+	}
+
 	return data, nil
 }

--- a/pkg/enhancers/gitlab/gitlab.go
+++ b/pkg/enhancers/gitlab/gitlab.go
@@ -99,6 +99,10 @@ func handleLocalImport(importData *models.Import) (*enhancers.ImportedPipeline, 
 }
 
 func (g *GitLabEnhancer) Enhance(data *models.Pipeline, importedPipelines []*enhancers.ImportedPipeline) (*models.Pipeline, error) {
+	if data == nil {
+		return data, nil
+	}
+
 	for i, importData := range data.Imports {
 		importedPipeline := importedPipelines[i]
 		if importedPipeline != nil {

--- a/pkg/enhancers/gitlab/gitlab.go
+++ b/pkg/enhancers/gitlab/gitlab.go
@@ -25,8 +25,13 @@ func (g *GitLabEnhancer) LoadImportedPipelines(data *models.Pipeline, credential
 		for _, importData := range data.Imports {
 			importedPipeline, err := handleImport(importData, credentials)
 			if err != nil {
+				if errs == nil {
+					errs = errors.New("got error(s) importing pipeline(s):")
+				}
 				errs = errors.Wrap(errs, fmt.Sprintf("error importing pipeline: %s", err.Error()))
 			}
+
+			// We append nil imported pipelines to maintain the order of the imported pipelines
 			importedPipelines = append(importedPipelines, importedPipeline)
 		}
 	}

--- a/pkg/enhancers/gitlab/gitlab_test.go
+++ b/pkg/enhancers/gitlab/gitlab_test.go
@@ -373,3 +373,115 @@ func TestGitLabEnhancer_LoadImportedPipelines(t *testing.T) {
 		})
 	}
 }
+
+func TestGitLabEnhancer_Enhance(t *testing.T) {
+	type args struct {
+		data              *models.Pipeline
+		importedPipelines []*enhancers.ImportedPipeline
+	}
+	tests := []struct {
+		name    string
+		g       *GitLabEnhancer
+		args    args
+		want    *models.Pipeline
+		wantErr bool
+	}{
+		{
+			name: "valid local import",
+			args: args{
+				data: &models.Pipeline{
+					Imports: []*models.Import{
+						{
+							Source: &models.ImportSource{
+								Type: models.SourceTypeLocal,
+								SCM:  consts.GitLabPlatform,
+								Path: utils.GetPtr("testdata/pipeline.yaml"),
+							},
+						},
+						{
+							Source: &models.ImportSource{
+								Type:         models.SourceTypeRemote,
+								SCM:          consts.GitLabPlatform,
+								Path:         utils.GetPtr("pipeline.yaml"),
+								Organization: utils.GetPtr("group"),
+								Repository:   utils.GetPtr("subgroup/project"),
+							},
+							Version:     utils.GetPtr("invalidbranch"),
+							VersionType: models.BranchVersion,
+						},
+						{
+							Source: &models.ImportSource{
+								Type: models.SourceTypeLocal,
+								SCM:  consts.GitLabPlatform,
+								Path: utils.GetPtr("testdata/pipeline.yaml"),
+							},
+						},
+					},
+				},
+				importedPipelines: []*enhancers.ImportedPipeline{
+					{
+						Data:     []byte("test data\n"),
+						Pipeline: &models.Pipeline{Name: utils.GetPtr("test")},
+					},
+					nil,
+					{
+						Data:     []byte("test data\n"),
+						Pipeline: &models.Pipeline{Name: utils.GetPtr("test")},
+					},
+				},
+			},
+			want: &models.Pipeline{
+				Imports: []*models.Import{
+					{
+						Source: &models.ImportSource{
+							Type: models.SourceTypeLocal,
+							SCM:  consts.GitLabPlatform,
+							Path: utils.GetPtr("testdata/pipeline.yaml"),
+						},
+						Pipeline: &models.Pipeline{Name: utils.GetPtr("test")},
+					},
+					{
+						Source: &models.ImportSource{
+							Type:         models.SourceTypeRemote,
+							SCM:          consts.GitLabPlatform,
+							Path:         utils.GetPtr("pipeline.yaml"),
+							Organization: utils.GetPtr("group"),
+							Repository:   utils.GetPtr("subgroup/project"),
+						},
+						Version:     utils.GetPtr("invalidbranch"),
+						VersionType: models.BranchVersion,
+					},
+					{
+						Source: &models.ImportSource{
+							Type: models.SourceTypeLocal,
+							SCM:  consts.GitLabPlatform,
+							Path: utils.GetPtr("testdata/pipeline.yaml"),
+						},
+						Pipeline: &models.Pipeline{Name: utils.GetPtr("test")},
+					},
+				},
+			},
+		},
+		{
+			name: "nil pipeline",
+			args: args{
+				data:              nil,
+				importedPipelines: nil,
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &GitLabEnhancer{}
+			got, err := g.Enhance(tt.args.data, tt.args.importedPipelines)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GitLabEnhancer.Enhance() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GitLabEnhancer.Enhance() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/enhancers/gitlab/gitlab_test.go
+++ b/pkg/enhancers/gitlab/gitlab_test.go
@@ -1,0 +1,375 @@
+package gitlab
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/argonsecurity/pipeline-parser/pkg/consts"
+	"github.com/argonsecurity/pipeline-parser/pkg/enhancers"
+	"github.com/argonsecurity/pipeline-parser/pkg/models"
+	"github.com/argonsecurity/pipeline-parser/pkg/utils"
+)
+
+func Test_handleLocalImport(t *testing.T) {
+	type args struct {
+		importData *models.Import
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *enhancers.ImportedPipeline
+		wantErr bool
+	}{
+		{
+			name: "valid local import",
+			args: args{
+				importData: &models.Import{
+					Source: &models.ImportSource{
+						Type: models.SourceTypeLocal,
+						SCM:  consts.GitLabPlatform,
+						Path: utils.GetPtr("testdata/pipeline.yaml"),
+					},
+				},
+			},
+			want: &enhancers.ImportedPipeline{
+				Data: []byte("test data\n"),
+			},
+		},
+		{
+			name: "invalid local import",
+			args: args{
+				importData: &models.Import{
+					Source: &models.ImportSource{
+						Type: models.SourceTypeLocal,
+						SCM:  consts.GitLabPlatform,
+						Path: utils.GetPtr("testdata/invalid.yaml"),
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := handleLocalImport(tt.args.importData)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("handleLocalImport() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("handleLocalImport() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_handleRemoteImport(t *testing.T) {
+	type args struct {
+		importData  *models.Import
+		credentials *models.Credentials
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *enhancers.ImportedPipeline
+		wantErr bool
+	}{
+		{
+			name: "valid remote import",
+			args: args{
+				importData: &models.Import{
+					Source: &models.ImportSource{
+						Type:         models.SourceTypeRemote,
+						SCM:          consts.GitLabPlatform,
+						Path:         utils.GetPtr("pipeline.yaml"),
+						Organization: utils.GetPtr("group"),
+						Repository:   utils.GetPtr("subgroup/project"),
+					},
+					Version:     utils.GetPtr("master"),
+					VersionType: models.BranchVersion,
+				},
+			},
+			want: &enhancers.ImportedPipeline{
+				Data: []byte("test data\n"),
+			},
+		},
+		{
+			name: "invalid remote import",
+			args: args{
+				importData: &models.Import{
+					Source: &models.ImportSource{
+						Type:         models.SourceTypeRemote,
+						SCM:          consts.GitLabPlatform,
+						Path:         utils.GetPtr("pipeline.yaml"),
+						Organization: utils.GetPtr("group"),
+						Repository:   utils.GetPtr("subgroup/project"),
+					},
+					Version:     utils.GetPtr("invalidbranch"),
+					VersionType: models.BranchVersion,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "nil values",
+			args: args{
+				importData: &models.Import{
+					Source: &models.ImportSource{
+						Type: models.SourceTypeRemote,
+						SCM:  consts.GitLabPlatform,
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		h := http.FileServer(http.Dir("testdata"))
+		ts := httptest.NewServer(h)
+		defer ts.Close()
+		GITLAB_BASE_URL = ts.URL
+
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := handleRemoteImport(tt.args.importData, tt.args.credentials)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("handleRemoteImport() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("handleRemoteImport() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_handleImport(t *testing.T) {
+	type args struct {
+		importData  *models.Import
+		credentials *models.Credentials
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *enhancers.ImportedPipeline
+		wantErr bool
+	}{
+		{
+			name: "valid local import",
+			args: args{
+				importData: &models.Import{
+					Source: &models.ImportSource{
+						Type: models.SourceTypeLocal,
+						SCM:  consts.GitLabPlatform,
+						Path: utils.GetPtr("testdata/pipeline.yaml"),
+					},
+				},
+			},
+			want: &enhancers.ImportedPipeline{
+				Data: []byte("test data\n"),
+			},
+		},
+		{
+			name: "valid remote import",
+			args: args{
+				importData: &models.Import{
+					Source: &models.ImportSource{
+						Type:         models.SourceTypeRemote,
+						SCM:          consts.GitLabPlatform,
+						Path:         utils.GetPtr("pipeline.yaml"),
+						Organization: utils.GetPtr("group"),
+						Repository:   utils.GetPtr("subgroup/project"),
+					},
+					Version:     utils.GetPtr("master"),
+					VersionType: models.BranchVersion,
+				},
+			},
+			want: &enhancers.ImportedPipeline{
+				Data: []byte("test data\n"),
+			},
+		},
+		{
+			name: "invalid remote import",
+			args: args{
+				importData: &models.Import{
+					Source: &models.ImportSource{
+						Type:         models.SourceTypeRemote,
+						SCM:          consts.GitLabPlatform,
+						Path:         utils.GetPtr("pipeline.yaml"),
+						Organization: utils.GetPtr("group"),
+						Repository:   utils.GetPtr("subgroup/project"),
+					},
+					Version:     utils.GetPtr("invalidbranch"),
+					VersionType: models.BranchVersion,
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		h := http.FileServer(http.Dir("testdata"))
+		ts := httptest.NewServer(h)
+		defer ts.Close()
+		GITLAB_BASE_URL = ts.URL
+
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := handleImport(tt.args.importData, tt.args.credentials)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("handleImport() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("handleImport() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGitLabEnhancer_LoadImportedPipelines(t *testing.T) {
+	type args struct {
+		data        *models.Pipeline
+		credentials *models.Credentials
+	}
+	tests := []struct {
+		name    string
+		g       *GitLabEnhancer
+		args    args
+		want    []*enhancers.ImportedPipeline
+		wantErr bool
+	}{
+		{
+			name: "valid local import",
+			args: args{
+				data: &models.Pipeline{
+					Imports: []*models.Import{
+						{
+							Source: &models.ImportSource{
+								Type: models.SourceTypeLocal,
+								SCM:  consts.GitLabPlatform,
+								Path: utils.GetPtr("testdata/pipeline.yaml"),
+							},
+						},
+					},
+				},
+			},
+			want: []*enhancers.ImportedPipeline{
+				{
+					Data: []byte("test data\n"),
+				},
+			},
+		},
+		{
+			name: "valid remote import",
+			args: args{
+				data: &models.Pipeline{
+					Imports: []*models.Import{
+						{
+							Source: &models.ImportSource{
+								Type:         models.SourceTypeRemote,
+								SCM:          consts.GitLabPlatform,
+								Path:         utils.GetPtr("pipeline.yaml"),
+								Organization: utils.GetPtr("group"),
+								Repository:   utils.GetPtr("subgroup/project"),
+							},
+							Version:     utils.GetPtr("master"),
+							VersionType: models.BranchVersion,
+						},
+					},
+				},
+			},
+			want: []*enhancers.ImportedPipeline{
+				{
+					Data: []byte("test data\n"),
+				},
+			},
+		},
+		{
+			name: "multiple imports - some invalid",
+			args: args{
+				data: &models.Pipeline{
+					Imports: []*models.Import{
+						{
+							Source: &models.ImportSource{
+								Type: models.SourceTypeLocal,
+								SCM:  consts.GitLabPlatform,
+								Path: utils.GetPtr("testdata/pipeline.yaml"),
+							},
+						},
+						{
+							Source: &models.ImportSource{
+								Type:         models.SourceTypeRemote,
+								SCM:          consts.GitLabPlatform,
+								Path:         utils.GetPtr("pipeline.yaml"),
+								Organization: utils.GetPtr("group"),
+								Repository:   utils.GetPtr("subgroup/project"),
+							},
+							Version:     utils.GetPtr("master"),
+							VersionType: models.BranchVersion,
+						},
+						{
+							Source: &models.ImportSource{
+								Type:         models.SourceTypeRemote,
+								SCM:          consts.GitLabPlatform,
+								Path:         utils.GetPtr("pipeline.yaml"),
+								Organization: utils.GetPtr("group"),
+								Repository:   utils.GetPtr("subgroup/project"),
+							},
+							Version:     utils.GetPtr("invalidbranch"),
+							VersionType: models.BranchVersion,
+						},
+					},
+				},
+			},
+			want: []*enhancers.ImportedPipeline{
+				{
+					Data: []byte("test data\n"),
+				},
+				{
+					Data: []byte("test data\n"),
+				},
+				nil,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid remote import",
+			args: args{
+				data: &models.Pipeline{
+					Imports: []*models.Import{
+						{
+							Source: &models.ImportSource{
+								Type:         models.SourceTypeRemote,
+								SCM:          consts.GitLabPlatform,
+								Path:         utils.GetPtr("pipeline.yaml"),
+								Organization: utils.GetPtr("group"),
+								Repository:   utils.GetPtr("subgroup/project"),
+							},
+							Version:     utils.GetPtr("invalidbranch"),
+							VersionType: models.BranchVersion,
+						},
+					},
+				},
+			},
+			want:    []*enhancers.ImportedPipeline{nil},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		h := http.FileServer(http.Dir("testdata"))
+		ts := httptest.NewServer(h)
+		defer ts.Close()
+		GITLAB_BASE_URL = ts.URL
+		t.Run(tt.name, func(t *testing.T) {
+			g := &GitLabEnhancer{}
+			got, err := g.LoadImportedPipelines(tt.args.data, tt.args.credentials)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GitLabEnhancer.LoadImportedPipelines() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GitLabEnhancer.LoadImportedPipelines() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/enhancers/gitlab/testdata/group/subgroup/project/-/raw/master/pipeline.yaml
+++ b/pkg/enhancers/gitlab/testdata/group/subgroup/project/-/raw/master/pipeline.yaml
@@ -1,0 +1,1 @@
+test data

--- a/pkg/enhancers/gitlab/testdata/pipeline.yaml
+++ b/pkg/enhancers/gitlab/testdata/pipeline.yaml
@@ -1,0 +1,1 @@
+test data

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -69,6 +69,9 @@ func handle[T any](data []byte, handler Handler[T], credentials *models.Credenti
 	}
 
 	for _, importedPipeline := range importedPipelines {
+		if importedPipeline == nil {
+			continue
+		}
 		parsedImportedPipeline, err := handle(importedPipeline.Data, handler, credentials)
 		if err != nil {
 			fmt.Printf("Failed parsing imported pipeline for job %s - %v", importedPipeline.JobName, err)

--- a/pkg/loaders/gitlab/gitlab_test.go
+++ b/pkg/loaders/gitlab/gitlab_test.go
@@ -144,16 +144,6 @@ func TestLoad(t *testing.T) {
 			Name:     "Terraform",
 			Filename: "../../../test/fixtures/gitlab/terraform.yaml",
 			ExpectedGitlabCIConfig: &models.GitlabCIConfiguration{
-				Include: &models.Include{
-					{
-						Template:      "Terraform/Base.latest.gitlab-ci.yml",
-						FileReference: testutils.CreateFileReference(7, 5, 7, 50),
-					},
-					{
-						Template:      "Jobs/SAST-IaC.latest.gitlab-ci.yml",
-						FileReference: testutils.CreateFileReference(8, 5, 8, 49),
-					},
-				},
 				Stages: []string{
 					"validate",
 					"test",
@@ -163,17 +153,17 @@ func TestLoad(t *testing.T) {
 				Jobs: map[string]*models.Job{
 					"validate": {
 						Extends:       ".terraform:validate",
-						FileReference: testutils.CreateFileReference(20, 1, 22, 10),
+						FileReference: testutils.CreateFileReference(16, 1, 18, 10),
 						Needs:         &job.Needs{},
 					},
 					"fmt": {
 						Extends:       ".terraform:fmt",
-						FileReference: testutils.CreateFileReference(16, 1, 18, 10),
+						FileReference: testutils.CreateFileReference(12, 1, 14, 10),
 						Needs:         &job.Needs{},
 					},
 					"build": {
 						Extends:       ".terraform:build",
-						FileReference: testutils.CreateFileReference(24, 1, 25, 28),
+						FileReference: testutils.CreateFileReference(20, 1, 21, 28),
 					},
 					"deploy": {
 						Extends: ".terraform:deploy",
@@ -192,12 +182,6 @@ func TestLoad(t *testing.T) {
 			Name:     "Baserow",
 			Filename: "../../../test/fixtures/gitlab/baserow.yaml",
 			ExpectedGitlabCIConfig: &models.GitlabCIConfiguration{
-				Include: &models.Include{
-					{
-						Local:         "/.gitlab/ci_includes/jobs.yml",
-						FileReference: testutils.CreateFileReference(178, 10, 178, 39),
-					},
-				},
 				Stages: []string{
 					"build",
 					"test",
@@ -208,7 +192,7 @@ func TestLoad(t *testing.T) {
 					"build-ci-util-image": {
 						Image: &common.Image{
 							Name:          "docker:20.10.12",
-							FileReference: testutils.CreateFileReference(204, 3, 204, 25),
+							FileReference: testutils.CreateFileReference(202, 3, 202, 25),
 						},
 						Stage:    "build",
 						Services: []any{"docker:20.10.12-dind"},
@@ -217,13 +201,13 @@ func TestLoad(t *testing.T) {
 								"DOCKER_BUILDKIT": "1",
 								"DOCKER_HOST":     "tcp://docker:2376",
 							},
-							FileReference: testutils.CreateFileReference(207, 1, 210, 37),
+							FileReference: testutils.CreateFileReference(205, 1, 208, 37),
 						},
 						BeforeScript: &common.Script{
 							Commands: []string{
 								"echo \"$CI_REGISTRY_PASSWORD\" | \\\n  docker login -u \"$CI_REGISTRY_USER\" \"$CI_REGISTRY\" --password-stdin\n",
 							},
-							FileReference: testutils.CreateFileReference(211, 3, 214, 7),
+							FileReference: testutils.CreateFileReference(209, 3, 212, 7),
 						},
 						Script: &common.Script{
 							Commands: []string{
@@ -231,19 +215,19 @@ func TestLoad(t *testing.T) {
 								"docker build -t $CI_UTIL_IMAGE .",
 								"docker push $CI_UTIL_IMAGE",
 							},
-							FileReference: testutils.CreateFileReference(215, 3, 218, 33),
+							FileReference: testutils.CreateFileReference(213, 3, 216, 33),
 						},
 						When: "manual",
 						Only: &job.Controls{
 							Changes:       []string{".gitlab/ci_util_image/*"},
-							FileReference: testutils.CreateFileReference(220, 3, 222, 32),
+							FileReference: testutils.CreateFileReference(218, 3, 220, 32),
 						},
 						Except: &job.Controls{
 							Refs: []string{
 								"pipelines",
 								"tags",
 							},
-							FileReference: testutils.CreateFileReference(223, 3, 226, 13),
+							FileReference: testutils.CreateFileReference(221, 3, 224, 13),
 						},
 						Parallel: &job.Parallel{
 							Matrix: &job.Matrix{
@@ -255,7 +239,7 @@ func TestLoad(t *testing.T) {
 								},
 							},
 						},
-						FileReference: testutils.CreateFileReference(203, 1, 230, 20),
+						FileReference: testutils.CreateFileReference(201, 1, 228, 20),
 					},
 				},
 				Variables: &common.EnvironmentVariablesRef{
@@ -267,7 +251,7 @@ func TestLoad(t *testing.T) {
 						"TESTED_IMAGE_PREFIX":        "ci-tested-",
 						"BACKEND_IMAGE_NAME":         "backend",
 					},
-					FileReference: testutils.CreateFileReference(186, 1, 200, 32),
+					FileReference: testutils.CreateFileReference(184, 1, 198, 32),
 				},
 			},
 		},
@@ -277,8 +261,8 @@ func TestLoad(t *testing.T) {
 			ExpectedGitlabCIConfig: &models.GitlabCIConfiguration{
 				Include: &models.Include{
 					{
-						Local:         "/test/fixtures/gitlab/gradle.yaml",
-						FileReference: testutils.CreateFileReference(1, 10, 1, 43),
+						Local:         "/../../test/fixtures/gitlab/gradle.yaml",
+						FileReference: testutils.CreateFileReference(1, 10, 1, 49),
 					},
 				},
 			},
@@ -289,8 +273,8 @@ func TestLoad(t *testing.T) {
 			ExpectedGitlabCIConfig: &models.GitlabCIConfiguration{
 				Include: &models.Include{
 					{
-						Remote:        "https://gitlab.com/gitlab-org/gitlab/-/raw/master/lib/gitlab/ci/templates/Gradle.gitlab-ci.yml",
-						FileReference: testutils.CreateFileReference(1, 10, 1, 104),
+						Remote:        "https://gitlab.com/gitlab-org/gitlab/-/raw/master/imported.yaml",
+						FileReference: testutils.CreateFileReference(1, 10, 1, 73),
 					},
 				},
 			},
@@ -301,18 +285,18 @@ func TestLoad(t *testing.T) {
 			ExpectedGitlabCIConfig: &models.GitlabCIConfiguration{
 				Include: &models.Include{
 					{
-						File:          "/lib/gitlab/ci/templates/Gradle.gitlab-ci.yml",
+						File:          "/imported.yaml",
 						Ref:           "master",
 						Project:       "gitlab-org/gitlab",
 						FileReference: testutils.CreateFileReference(2, 5, 4, 16),
 					},
 					{
-						Remote:        "https://gitlab.com/gitlab-org/gitlab/-/raw/master/lib/gitlab/ci/templates/Gradle.gitlab-ci.yml",
-						FileReference: testutils.CreateFileReference(5, 5, 5, 99),
+						Remote:        "https://gitlab.com/gitlab-org/gitlab/-/raw/master/imported.yaml",
+						FileReference: testutils.CreateFileReference(5, 5, 5, 68),
 					},
 					{
-						Local:         "/test/fixtures/gitlab/gradle.yaml",
-						FileReference: testutils.CreateFileReference(6, 5, 6, 38),
+						Local:         "/../../test/fixtures/gitlab/gradle.yaml",
+						FileReference: testutils.CreateFileReference(6, 5, 6, 44),
 					},
 					{
 						Template:      "Android.gitlab-ci.yml",

--- a/pkg/loaders/gitlab/gitlab_test.go
+++ b/pkg/loaders/gitlab/gitlab_test.go
@@ -314,6 +314,10 @@ func TestLoad(t *testing.T) {
 						Local:         "/test/fixtures/gitlab/gradle.yaml",
 						FileReference: testutils.CreateFileReference(6, 5, 6, 38),
 					},
+					{
+						Template:      "Android.gitlab-ci.yml",
+						FileReference: testutils.CreateFileReference(7, 5, 7, 36),
+					},
 				},
 			},
 		},

--- a/pkg/loaders/gitlab/gitlab_test.go
+++ b/pkg/loaders/gitlab/gitlab_test.go
@@ -194,7 +194,8 @@ func TestLoad(t *testing.T) {
 			ExpectedGitlabCIConfig: &models.GitlabCIConfiguration{
 				Include: &models.Include{
 					{
-						Local: "/.gitlab/ci_includes/jobs.yml",
+						Local:         "/.gitlab/ci_includes/jobs.yml",
+						FileReference: testutils.CreateFileReference(178, 10, 178, 39),
 					},
 				},
 				Stages: []string{
@@ -267,6 +268,52 @@ func TestLoad(t *testing.T) {
 						"BACKEND_IMAGE_NAME":         "backend",
 					},
 					FileReference: testutils.CreateFileReference(186, 1, 200, 32),
+				},
+			},
+		},
+		{
+			Name:     "Include Local",
+			Filename: "../../../test/fixtures/gitlab/include-local.yaml",
+			ExpectedGitlabCIConfig: &models.GitlabCIConfiguration{
+				Include: &models.Include{
+					{
+						Local:         "/test/fixtures/gitlab/gradle.yaml",
+						FileReference: testutils.CreateFileReference(1, 10, 1, 43),
+					},
+				},
+			},
+		},
+		{
+			Name:     "Include Remote",
+			Filename: "../../../test/fixtures/gitlab/include-remote.yaml",
+			ExpectedGitlabCIConfig: &models.GitlabCIConfiguration{
+				Include: &models.Include{
+					{
+						Remote:        "https://gitlab.com/gitlab-org/gitlab/-/raw/master/lib/gitlab/ci/templates/Gradle.gitlab-ci.yml",
+						FileReference: testutils.CreateFileReference(1, 10, 1, 104),
+					},
+				},
+			},
+		},
+		{
+			Name:     "Include Multiple",
+			Filename: "../../../test/fixtures/gitlab/include-multiple.yaml",
+			ExpectedGitlabCIConfig: &models.GitlabCIConfiguration{
+				Include: &models.Include{
+					{
+						File:          "/lib/gitlab/ci/templates/Gradle.gitlab-ci.yml",
+						Ref:           "master",
+						Project:       "gitlab-org/gitlab",
+						FileReference: testutils.CreateFileReference(2, 5, 4, 16),
+					},
+					{
+						Remote:        "https://gitlab.com/gitlab-org/gitlab/-/raw/master/lib/gitlab/ci/templates/Gradle.gitlab-ci.yml",
+						FileReference: testutils.CreateFileReference(5, 5, 5, 99),
+					},
+					{
+						Local:         "/test/fixtures/gitlab/gradle.yaml",
+						FileReference: testutils.CreateFileReference(6, 5, 6, 38),
+					},
 				},
 			},
 		},

--- a/pkg/models/import.go
+++ b/pkg/models/import.go
@@ -1,0 +1,26 @@
+package models
+
+type SourceType string
+
+const (
+	SourceTypeLocal  SourceType = "local"
+	SourceTypeRemote SourceType = "remote"
+)
+
+type ImportSource struct {
+	SCM          Platform   `json:"scm,omitempty"`
+	Organization *string    `json:"organization,omitempty"`
+	Repository   *string    `json:"repository,omitempty"`
+	Path         *string    `json:"path,omitempty"`
+	Type         SourceType `json:"type,omitempty"`
+}
+
+type Import struct {
+	Source        *ImportSource  `json:"source,omitempty"`
+	Version       *string        `json:"version,omitempty"`
+	VersionType   VersionType    `json:"version_type,omitempty"`
+	Pipeline      *Pipeline      `json:"pipeline,omitempty"`
+	Parameters    map[string]any `json:"parameters,omitempty"`
+	Secrets       *SecretsRef    `json:"secrets,omitempty"`
+	FileReference *FileReference `json:"file_reference,omitempty"`
+}

--- a/pkg/models/job.go
+++ b/pkg/models/job.go
@@ -13,30 +13,6 @@ type SecretsRef struct {
 	FileReference *FileReference `json:"file_reference,omitempty"`
 }
 
-type SourceType string
-
-const (
-	SourceTypeLocal  SourceType = "local"
-	SourceTypeRemote SourceType = "remote"
-)
-
-type ImportSource struct {
-	SCM          Platform   `json:"scm,omitempty"`
-	Organization *string    `json:"organization,omitempty"`
-	Repository   *string    `json:"repository,omitempty"`
-	Path         *string    `json:"path,omitempty"`
-	Type         SourceType `json:"type,omitempty"`
-}
-
-type Import struct {
-	Source      *ImportSource  `json:"source,omitempty"`
-	Version     *string        `json:"version,omitempty"`
-	VersionType VersionType    `json:"version_type,omitempty"`
-	Pipeline    *Pipeline      `json:"pipeline,omitempty"`
-	Parameters  map[string]any `json:"parameters,omitempty"`
-	Secrets     *SecretsRef    `json:"secrets,omitempty"`
-}
-
 type Job struct {
 	ID                   *string                  `json:"id,omitempty"`
 	Name                 *string                  `json:"name,omitempty"`

--- a/pkg/models/pipeline.go
+++ b/pkg/models/pipeline.go
@@ -5,7 +5,7 @@ type Pipeline struct {
 	Name       *string      `json:"name,omitempty"`
 	Triggers   *Triggers    `json:"triggers,omitempty"`
 	Jobs       []*Job       `json:"jobs,omitempty"`
-	Imports    []string     `json:"imports,omitempty"`
+	Imports    []*Import    `json:"imports,omitempty"`
 	Parameters []*Parameter `json:"parameters,omitempty"`
 	Defaults   *Defaults    `json:"defaults,omitempty"`
 }

--- a/pkg/parsers/azure/azure.go
+++ b/pkg/parsers/azure/azure.go
@@ -20,7 +20,7 @@ func (g *AzureParser) Parse(azurePipeline *azureModels.Pipeline) (*models.Pipeli
 	pipeline.Defaults = parsePipelineDefaults(azurePipeline)
 	pipeline.Triggers = parsePipelineTriggers(azurePipeline)
 	pipeline.Parameters = parseParameters(azurePipeline.Parameters)
-	pipeline.Imports = parseExtends(azurePipeline.Extends)
+	// pipeline.Imports = parseExtends(azurePipeline.Extends)
 
 	var jobs []*models.Job
 

--- a/pkg/parsers/azure/azure.go
+++ b/pkg/parsers/azure/azure.go
@@ -20,7 +20,6 @@ func (g *AzureParser) Parse(azurePipeline *azureModels.Pipeline) (*models.Pipeli
 	pipeline.Defaults = parsePipelineDefaults(azurePipeline)
 	pipeline.Triggers = parsePipelineTriggers(azurePipeline)
 	pipeline.Parameters = parseParameters(azurePipeline.Parameters)
-	// pipeline.Imports = parseExtends(azurePipeline.Extends)
 
 	var jobs []*models.Job
 

--- a/pkg/parsers/github/common.go
+++ b/pkg/parsers/github/common.go
@@ -1,15 +1,8 @@
 package github
 
 import (
-	"regexp"
-
 	githubModels "github.com/argonsecurity/pipeline-parser/pkg/loaders/github/models"
 	"github.com/argonsecurity/pipeline-parser/pkg/models"
-)
-
-var (
-	sha1Regex   = regexp.MustCompile(`[0-9a-fA-F]{40}`)
-	semverRegex = regexp.MustCompile(`v?([0-9]+)(\.[0-9]+)?(\.[0-9]+)?(-([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?(\+([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?`)
 )
 
 func parseEnvironmentVariablesRef(envRef *githubModels.EnvironmentVariablesRef) *models.EnvironmentVariablesRef {
@@ -21,20 +14,4 @@ func parseEnvironmentVariablesRef(envRef *githubModels.EnvironmentVariablesRef) 
 		EnvironmentVariables: envRef.EnvironmentVariables,
 		FileReference:        envRef.FileReference,
 	}
-}
-
-func detectVersionType(version string) models.VersionType {
-	versionType := models.None
-
-	if version != "" {
-		if sha1Regex.MatchString(version) {
-			versionType = models.CommitSHA
-		} else if semverRegex.MatchString(version) {
-			versionType = models.TagVersion
-		} else {
-			versionType = models.BranchVersion
-		}
-	}
-
-	return versionType
 }

--- a/pkg/parsers/github/common_test.go
+++ b/pkg/parsers/github/common_test.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	"reflect"
 	"testing"
 
 	githubModels "github.com/argonsecurity/pipeline-parser/pkg/loaders/github/models"
@@ -62,53 +61,6 @@ func TestParseEnvironmentVariablesRef(t *testing.T) {
 			got := parseEnvironmentVariablesRef(testCase.envRef)
 
 			testutils.DeepCompare(t, testCase.expectedEnv, got)
-		})
-	}
-}
-
-func Test_detectVersionType(t *testing.T) {
-	type args struct {
-		version string
-	}
-	tests := []struct {
-		name string
-		args args
-		want models.VersionType
-	}{
-		{
-			name: "Empty version",
-			args: args{
-				version: "",
-			},
-			want: models.None,
-		},
-		{
-			name: "Commit SHA",
-			args: args{
-				version: "1234567890123456789012345678901234567890",
-			},
-			want: models.CommitSHA,
-		},
-		{
-			name: "Tag version",
-			args: args{
-				version: "v1.2.3",
-			},
-			want: models.TagVersion,
-		},
-		{
-			name: "Branch version",
-			args: args{
-				version: "master",
-			},
-			want: models.BranchVersion,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := detectVersionType(tt.args.version); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("detectVersionType() = %v, want %v", got, tt.want)
-			}
 		})
 	}
 }

--- a/pkg/parsers/github/jobs.go
+++ b/pkg/parsers/github/jobs.go
@@ -7,6 +7,7 @@ import (
 	"github.com/argonsecurity/pipeline-parser/pkg/consts"
 	githubModels "github.com/argonsecurity/pipeline-parser/pkg/loaders/github/models"
 	"github.com/argonsecurity/pipeline-parser/pkg/models"
+	parserUtils "github.com/argonsecurity/pipeline-parser/pkg/parsers/utils"
 	"github.com/argonsecurity/pipeline-parser/pkg/utils"
 )
 
@@ -214,6 +215,6 @@ func parseJobUses(uses string) (org string, repo string, path string, version st
 		version = result[4]
 	}
 
-	versionType = detectVersionType(version)
+	versionType = parserUtils.DetectVersionType(version)
 	return
 }

--- a/pkg/parsers/github/steps.go
+++ b/pkg/parsers/github/steps.go
@@ -86,7 +86,7 @@ func parseActionHeader(header string) (string, string, models.VersionType) {
 		version = result[2]
 	}
 
-	versionType := detectVersionType(version)
+	versionType := parserUtils.DetectVersionType(version)
 
 	return actionName, version, versionType
 }

--- a/pkg/parsers/gitlab/imports.go
+++ b/pkg/parsers/gitlab/imports.go
@@ -1,27 +1,130 @@
 package gitlab
 
 import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/argonsecurity/pipeline-parser/pkg/consts"
 	gitlabModels "github.com/argonsecurity/pipeline-parser/pkg/loaders/gitlab/models"
+	"github.com/argonsecurity/pipeline-parser/pkg/models"
+	"github.com/argonsecurity/pipeline-parser/pkg/utils"
 )
 
-// TODO: add ref and project
-func parseImports(include *gitlabModels.Include) []string {
+var (
+	gitlabRemotePipelineRegex = regexp.MustCompile(`https://gitlab\.com/(?P<group>[\w-_]+)/(?P<project>.*?)/(?:-/)?raw/(?P<ref>.*?)/(?P<filePath>.*\.ya?ml)`)
+)
+
+func parseImports(include *gitlabModels.Include) []*models.Import {
 	if include == nil {
 		return nil
 	}
 
-	imports := []string{}
+	imports := []*models.Import{}
 	for _, item := range *include {
-		if item.Template != "" {
-			imports = append(imports, item.Template)
-		}
-		if item.Local != "" {
-			imports = append(imports, item.Local)
-		}
-		if item.Remote != "" {
-			imports = append(imports, item.Remote)
-		}
-
+		imports = append(imports, parseIncludeItem(item))
 	}
 	return imports
+}
+
+func parseIncludeItem(item gitlabModels.IncludeItem) *models.Import {
+	if item.Local != "" {
+		return parseLocalImport(&item)
+	}
+
+	if item.Remote != "" {
+		return parseRemoteImport(&item)
+	}
+
+	if item.File != "" {
+		return parseFileImport(&item)
+	}
+
+	if item.Template != "" {
+		return parseTemplateImport(&item)
+	}
+
+	return nil
+}
+
+func parseLocalImport(item *gitlabModels.IncludeItem) *models.Import {
+	if item.Local == "" {
+		return nil
+	}
+
+	return &models.Import{
+		Source: &models.ImportSource{
+			SCM:  consts.GitLabPlatform,
+			Type: models.SourceTypeLocal,
+			Path: &item.Local,
+		},
+		FileReference: item.FileReference,
+	}
+}
+
+func parseRemoteImport(item *gitlabModels.IncludeItem) *models.Import {
+	if item.Remote == "" {
+		return nil
+	}
+
+	group, project, ref, filePath := extractRemotePipelineInfo(item.Remote)
+	return &models.Import{
+		Source: &models.ImportSource{
+			SCM:          consts.GitLabPlatform,
+			Type:         models.SourceTypeRemote,
+			Organization: utils.GetPtr(group),
+			Repository:   utils.GetPtr(project),
+			Path:         utils.GetPtr(filePath),
+		},
+		Version:       utils.GetPtr(ref),
+		VersionType:   models.BranchVersion,
+		FileReference: item.FileReference,
+	}
+}
+
+func extractRemotePipelineInfo(url string) (group string, project string, ref string, filePath string) {
+	match := gitlabRemotePipelineRegex.FindStringSubmatch(url)
+	if len(match) == 5 {
+		return match[1], match[2], match[3], match[4]
+	}
+	return "", "", "", ""
+}
+
+func parseFileImport(item *gitlabModels.IncludeItem) *models.Import {
+	if item.File == "" {
+		return nil
+	}
+
+	splitProject := strings.SplitN(item.Project, "/", 2)
+	if len(splitProject) != 2 {
+		return nil
+	}
+
+	importData := &models.Import{
+		Source: &models.ImportSource{
+			SCM:          consts.GitLabPlatform,
+			Type:         models.SourceTypeRemote,
+			Path:         &item.File,
+			Repository:   utils.GetPtr(splitProject[1]),
+			Organization: utils.GetPtr(splitProject[0]),
+		},
+		FileReference: item.FileReference,
+	}
+
+	if item.Ref != "" {
+		importData.Version = &item.Ref
+		importData.VersionType = models.BranchVersion
+	}
+
+	return importData
+}
+
+func parseTemplateImport(item *gitlabModels.IncludeItem) *models.Import {
+	if item.Template == "" {
+		return nil
+	}
+
+	fullTemplateUrl := fmt.Sprintf("https://gitlab.com/gitlab-org/gitlab/-/raw/master/lib/gitlab/ci/templates/%s", item.Template)
+	item.Remote = fullTemplateUrl
+	return parseRemoteImport(item)
 }

--- a/pkg/parsers/gitlab/imports.go
+++ b/pkg/parsers/gitlab/imports.go
@@ -11,6 +11,10 @@ import (
 	"github.com/argonsecurity/pipeline-parser/pkg/utils"
 )
 
+const (
+	TEMPLATE_URL_FORMAT = "https://gitlab.com/gitlab-org/gitlab/-/raw/master/lib/gitlab/ci/templates/%s"
+)
+
 var (
 	gitlabRemotePipelineRegex = regexp.MustCompile(`https://gitlab\.com/(?P<group>[\w-_]+)/(?P<project>.*?)/(?:-/)?raw/(?P<ref>.*?)/(?P<filePath>.*\.ya?ml)`)
 )
@@ -124,7 +128,7 @@ func parseTemplateImport(item *gitlabModels.IncludeItem) *models.Import {
 		return nil
 	}
 
-	fullTemplateUrl := fmt.Sprintf("https://gitlab.com/gitlab-org/gitlab/-/raw/master/lib/gitlab/ci/templates/%s", item.Template)
+	fullTemplateUrl := fmt.Sprintf(TEMPLATE_URL_FORMAT, item.Template)
 	item.Remote = fullTemplateUrl
 	return parseRemoteImport(item)
 }

--- a/pkg/parsers/gitlab/imports.go
+++ b/pkg/parsers/gitlab/imports.go
@@ -26,7 +26,9 @@ func parseImports(include *gitlabModels.Include) []*models.Import {
 
 	imports := []*models.Import{}
 	for _, item := range *include {
-		imports = append(imports, parseIncludeItem(item))
+		if importItem := parseIncludeItem(item); importItem != nil {
+			imports = append(imports, importItem)
+		}
 	}
 	return imports
 }

--- a/pkg/parsers/gitlab/imports.go
+++ b/pkg/parsers/gitlab/imports.go
@@ -8,6 +8,7 @@ import (
 	"github.com/argonsecurity/pipeline-parser/pkg/consts"
 	gitlabModels "github.com/argonsecurity/pipeline-parser/pkg/loaders/gitlab/models"
 	"github.com/argonsecurity/pipeline-parser/pkg/models"
+	parserUtils "github.com/argonsecurity/pipeline-parser/pkg/parsers/utils"
 	"github.com/argonsecurity/pipeline-parser/pkg/utils"
 )
 
@@ -74,6 +75,7 @@ func parseRemoteImport(item *gitlabModels.IncludeItem) *models.Import {
 	}
 
 	group, project, ref, filePath := extractRemotePipelineInfo(item.Remote)
+	versionType := parserUtils.DetectVersionType(ref)
 	return &models.Import{
 		Source: &models.ImportSource{
 			SCM:          consts.GitLabPlatform,
@@ -83,7 +85,7 @@ func parseRemoteImport(item *gitlabModels.IncludeItem) *models.Import {
 			Path:         utils.GetPtr(filePath),
 		},
 		Version:       utils.GetPtr(ref),
-		VersionType:   models.BranchVersion,
+		VersionType:   versionType,
 		FileReference: item.FileReference,
 	}
 }
@@ -119,7 +121,7 @@ func parseFileImport(item *gitlabModels.IncludeItem) *models.Import {
 
 	if item.Ref != "" {
 		importData.Version = &item.Ref
-		importData.VersionType = models.BranchVersion
+		importData.VersionType = parserUtils.DetectVersionType(item.Ref)
 	}
 
 	return importData

--- a/pkg/parsers/gitlab/imports_test.go
+++ b/pkg/parsers/gitlab/imports_test.go
@@ -3,93 +3,607 @@ package gitlab
 import (
 	"testing"
 
+	"github.com/argonsecurity/pipeline-parser/pkg/consts"
 	gitlabModels "github.com/argonsecurity/pipeline-parser/pkg/loaders/gitlab/models"
+	"github.com/argonsecurity/pipeline-parser/pkg/models"
 	"github.com/argonsecurity/pipeline-parser/pkg/testutils"
+	"github.com/argonsecurity/pipeline-parser/pkg/utils"
+	"github.com/stretchr/testify/assert"
 )
 
-func TestParseImports(t *testing.T) {
-	testCases := []struct {
-		name            string
-		include         *gitlabModels.Include
-		expectedImports []string
+func Test_parseLocalImport(t *testing.T) {
+	type args struct {
+		item *gitlabModels.IncludeItem
+	}
+	tests := []struct {
+		name string
+		args args
+		want *models.Import
 	}{
 		{
-			name:            "Include is nil",
-			include:         nil,
-			expectedImports: nil,
-		},
-		{
-			name:            "Include is empty",
-			include:         &gitlabModels.Include{},
-			expectedImports: []string{},
-		},
-		{
-			name: "One include with all data",
-			include: &gitlabModels.Include{
-				{
-					Template: "template1",
-					Local:    "local1",
-					Remote:   "remote1",
+			name: "Local is empty",
+			args: args{
+				item: &gitlabModels.IncludeItem{
+					Local:         "",
+					FileReference: testutils.CreateFileReference(1, 1, 1, 1),
 				},
 			},
-			expectedImports: []string{"template1", "local1", "remote1"},
+			want: nil,
 		},
 		{
-			name: "Some includes with all data",
-			include: &gitlabModels.Include{
-				{
-					Template: "template1",
-					Local:    "local1",
-					Remote:   "remote1",
-				},
-				{
-					Template: "template2",
-					Local:    "local2",
-					Remote:   "remote2",
+			name: "Local is not empty",
+			args: args{
+				item: &gitlabModels.IncludeItem{
+					Local:         "local",
+					FileReference: testutils.CreateFileReference(1, 1, 1, 1),
 				},
 			},
-			expectedImports: []string{"template1", "local1", "remote1", "template2", "local2", "remote2"},
-		},
-		{
-			name:            "Include is empty",
-			include:         &gitlabModels.Include{},
-			expectedImports: []string{},
-		},
-		{
-			name: "One include with partial data",
-			include: &gitlabModels.Include{
-				{
-					Template: "template1",
-					Local:    "local1",
+			want: &models.Import{
+				Source: &models.ImportSource{
+					Type: models.SourceTypeLocal,
+					Path: utils.GetPtr("local"),
+					SCM:  consts.GitLabPlatform,
 				},
+				FileReference: testutils.CreateFileReference(1, 1, 1, 1),
 			},
-			expectedImports: []string{"template1", "local1"},
-		},
-		{
-			name: "Some includes with partial data",
-			include: &gitlabModels.Include{
-				{
-					Template: "template1",
-					Local:    "local1",
-				},
-				{
-					Template: "template2",
-					Remote:   "remote2",
-				},
-				{
-					Local:  "local3",
-					Remote: "remote3",
-				},
-			},
-			expectedImports: []string{"template1", "local1", "template2", "remote2", "local3", "remote3"},
 		},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseLocalImport(tt.args.item)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
 
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			got := parseImports(testCase.include)
+func Test_parseRemoteImport(t *testing.T) {
+	type args struct {
+		item *gitlabModels.IncludeItem
+	}
+	tests := []struct {
+		name string
+		args args
+		want *models.Import
+	}{
+		{
+			name: "Remote is empty",
+			args: args{
+				item: &gitlabModels.IncludeItem{
+					Remote:        "",
+					FileReference: testutils.CreateFileReference(1, 1, 1, 1),
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "Remote is not empty",
+			args: args{
+				item: &gitlabModels.IncludeItem{
+					Remote:        "https://gitlab.com/group/subgroup/project/-/raw/master/.gitlab-ci.yml",
+					FileReference: testutils.CreateFileReference(1, 1, 1, 1),
+				},
+			},
+			want: &models.Import{
+				Source: &models.ImportSource{
+					Type:         models.SourceTypeRemote,
+					Path:         utils.GetPtr(".gitlab-ci.yml"),
+					SCM:          consts.GitLabPlatform,
+					Repository:   utils.GetPtr("subgroup/project"),
+					Organization: utils.GetPtr("group"),
+				},
+				Version:       utils.GetPtr("master"),
+				VersionType:   models.BranchVersion,
+				FileReference: testutils.CreateFileReference(1, 1, 1, 1),
+			},
+		},
+		{
+			name: "Remote is an invalid url",
+			args: args{
+				item: &gitlabModels.IncludeItem{
+					Remote:        "https://gitlab.com/group/subgroup/project/-/raw/master",
+					FileReference: testutils.CreateFileReference(1, 1, 1, 1),
+				},
+			},
+			want: &models.Import{
+				Source: &models.ImportSource{
+					Type:         models.SourceTypeRemote,
+					Path:         utils.GetPtr(""),
+					SCM:          consts.GitLabPlatform,
+					Repository:   utils.GetPtr(""),
+					Organization: utils.GetPtr(""),
+				},
+				FileReference: testutils.CreateFileReference(1, 1, 1, 1),
+				Version:       utils.GetPtr(""),
+				VersionType:   models.BranchVersion,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseRemoteImport(tt.args.item)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
 
-			testutils.DeepCompare(t, testCase.expectedImports, got)
+func Test_extractRemotePipelineInfo(t *testing.T) {
+	type args struct {
+		url string
+	}
+	tests := []struct {
+		name         string
+		args         args
+		wantGroup    string
+		wantProject  string
+		wantRef      string
+		wantFilePath string
+	}{
+		{
+			name: "Valid url",
+			args: args{
+				url: "https://gitlab.com/group/subgroup/project/-/raw/master/.gitlab-ci.yml",
+			},
+			wantGroup:    "group",
+			wantProject:  "subgroup/project",
+			wantRef:      "master",
+			wantFilePath: ".gitlab-ci.yml",
+		},
+		{
+			name: "Invalid url",
+			args: args{
+				url: "https://gitlab.com/group/subgroup/project/-/raw/master",
+			},
+			wantGroup:    "",
+			wantProject:  "",
+			wantRef:      "",
+			wantFilePath: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotGroup, gotProject, gotRef, gotFilePath := extractRemotePipelineInfo(tt.args.url)
+			if gotGroup != tt.wantGroup {
+				t.Errorf("extractRemotePipelineInfo() gotGroup = %v, want %v", gotGroup, tt.wantGroup)
+			}
+			if gotProject != tt.wantProject {
+				t.Errorf("extractRemotePipelineInfo() gotProject = %v, want %v", gotProject, tt.wantProject)
+			}
+			if gotRef != tt.wantRef {
+				t.Errorf("extractRemotePipelineInfo() gotRef = %v, want %v", gotRef, tt.wantRef)
+			}
+			if gotFilePath != tt.wantFilePath {
+				t.Errorf("extractRemotePipelineInfo() gotFilePath = %v, want %v", gotFilePath, tt.wantFilePath)
+			}
+		})
+	}
+}
+
+func Test_parseFileImport(t *testing.T) {
+	type args struct {
+		item *gitlabModels.IncludeItem
+	}
+	tests := []struct {
+		name string
+		args args
+		want *models.Import
+	}{
+		{
+			name: "File is empty",
+			args: args{
+				item: &gitlabModels.IncludeItem{
+					File:          "",
+					FileReference: testutils.CreateFileReference(1, 1, 1, 1),
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "File is not empty",
+			args: args{
+				item: &gitlabModels.IncludeItem{
+					File:          ".gitlab-ci.yml",
+					Project:       "group/subgroup/project",
+					Ref:           "master",
+					FileReference: testutils.CreateFileReference(1, 1, 1, 1),
+				},
+			},
+			want: &models.Import{
+				Source: &models.ImportSource{
+					Type:         models.SourceTypeRemote,
+					Path:         utils.GetPtr(".gitlab-ci.yml"),
+					SCM:          consts.GitLabPlatform,
+					Repository:   utils.GetPtr("subgroup/project"),
+					Organization: utils.GetPtr("group"),
+				},
+				Version:       utils.GetPtr("master"),
+				VersionType:   models.BranchVersion,
+				FileReference: testutils.CreateFileReference(1, 1, 1, 1),
+			},
+		},
+		{
+			name: "ref is empty",
+			args: args{
+				item: &gitlabModels.IncludeItem{
+					File:          ".gitlab-ci.yml",
+					Project:       "group/subgroup/project",
+					Ref:           "",
+					FileReference: testutils.CreateFileReference(1, 1, 1, 1),
+				},
+			},
+			want: &models.Import{
+				Source: &models.ImportSource{
+					Type:         models.SourceTypeRemote,
+					Path:         utils.GetPtr(".gitlab-ci.yml"),
+					SCM:          consts.GitLabPlatform,
+					Repository:   utils.GetPtr("subgroup/project"),
+					Organization: utils.GetPtr("group"),
+				},
+				FileReference: testutils.CreateFileReference(1, 1, 1, 1),
+			},
+		},
+		{
+			name: "File is not empty and project is invalid",
+			args: args{
+				item: &gitlabModels.IncludeItem{
+					File:          ".gitlab-ci.yml",
+					Project:       "invalid",
+					Ref:           "master",
+					FileReference: testutils.CreateFileReference(1, 1, 1, 1),
+				},
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseFileImport(tt.args.item)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_parseTemplateImport(t *testing.T) {
+	type args struct {
+		item *gitlabModels.IncludeItem
+	}
+	tests := []struct {
+		name string
+		args args
+		want *models.Import
+	}{
+		{
+			name: "Template is empty",
+			args: args{
+				item: &gitlabModels.IncludeItem{
+					Template:      "",
+					FileReference: testutils.CreateFileReference(1, 1, 1, 1),
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "Regular template",
+			args: args{
+				item: &gitlabModels.IncludeItem{
+					Template:      "Android.gitlab-ci.yml",
+					FileReference: testutils.CreateFileReference(1, 1, 1, 1),
+				},
+			},
+			want: &models.Import{
+				Source: &models.ImportSource{
+					Type:         models.SourceTypeRemote,
+					Path:         utils.GetPtr("lib/gitlab/ci/templates/Android.gitlab-ci.yml"),
+					SCM:          consts.GitLabPlatform,
+					Repository:   utils.GetPtr("gitlab"),
+					Organization: utils.GetPtr("gitlab-org"),
+				},
+				FileReference: testutils.CreateFileReference(1, 1, 1, 1),
+				Version:       utils.GetPtr("master"),
+				VersionType:   models.BranchVersion,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseTemplateImport(tt.args.item)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_parseIncludeItem(t *testing.T) {
+	type args struct {
+		item gitlabModels.IncludeItem
+	}
+	tests := []struct {
+		name string
+		args args
+		want *models.Import
+	}{
+		{
+			name: "Local is empty",
+			args: args{
+				item: gitlabModels.IncludeItem{
+					Local:         "",
+					FileReference: testutils.CreateFileReference(1, 1, 1, 1),
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "Local is not empty",
+			args: args{
+				item: gitlabModels.IncludeItem{
+					Local:         "local",
+					FileReference: testutils.CreateFileReference(1, 1, 1, 1),
+				},
+			},
+			want: &models.Import{
+				Source: &models.ImportSource{
+					Type: models.SourceTypeLocal,
+					Path: utils.GetPtr("local"),
+					SCM:  consts.GitLabPlatform,
+				},
+				FileReference: testutils.CreateFileReference(1, 1, 1, 1),
+			},
+		},
+		{
+			name: "Remote is empty",
+			args: args{
+				item: gitlabModels.IncludeItem{
+					Remote:        "",
+					FileReference: testutils.CreateFileReference(1, 1, 1, 1),
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "Remote is not empty",
+			args: args{
+				item: gitlabModels.IncludeItem{
+					Remote:        "https://gitlab.com/group/subgroup/project/-/raw/master/.gitlab-ci.yml",
+					FileReference: testutils.CreateFileReference(1, 1, 1, 1),
+				},
+			},
+			want: &models.Import{
+				Source: &models.ImportSource{
+					Type:         models.SourceTypeRemote,
+					Path:         utils.GetPtr(".gitlab-ci.yml"),
+					SCM:          consts.GitLabPlatform,
+					Repository:   utils.GetPtr("subgroup/project"),
+					Organization: utils.GetPtr("group"),
+				},
+				Version:       utils.GetPtr("master"),
+				VersionType:   models.BranchVersion,
+				FileReference: testutils.CreateFileReference(1, 1, 1, 1),
+			},
+		},
+		{
+			name: "Remote is an invalid url",
+			args: args{
+				item: gitlabModels.IncludeItem{
+					Remote:        "https://gitlab.com/group/subgroup/project/-/raw/master",
+					FileReference: testutils.CreateFileReference(1, 1, 1, 1),
+				},
+			},
+			want: &models.Import{
+				Source: &models.ImportSource{
+					Type:         models.SourceTypeRemote,
+					Path:         utils.GetPtr(""),
+					SCM:          consts.GitLabPlatform,
+					Repository:   utils.GetPtr(""),
+					Organization: utils.GetPtr(""),
+				},
+				Version:       utils.GetPtr(""),
+				VersionType:   models.BranchVersion,
+				FileReference: testutils.CreateFileReference(1, 1, 1, 1),
+			},
+		},
+		{
+			name: "File is empty",
+			args: args{
+				item: gitlabModels.IncludeItem{
+					File:          "",
+					FileReference: testutils.CreateFileReference(1, 1, 1, 1),
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "File is not empty",
+			args: args{
+				item: gitlabModels.IncludeItem{
+					File:          ".gitlab-ci.yml",
+					Project:       "group/subgroup/project",
+					Ref:           "master",
+					FileReference: testutils.CreateFileReference(1, 1, 1, 1),
+				},
+			},
+			want: &models.Import{
+				Source: &models.ImportSource{
+					Type:         models.SourceTypeRemote,
+					Path:         utils.GetPtr(".gitlab-ci.yml"),
+					SCM:          consts.GitLabPlatform,
+					Repository:   utils.GetPtr("subgroup/project"),
+					Organization: utils.GetPtr("group"),
+				},
+				Version:       utils.GetPtr("master"),
+				VersionType:   models.BranchVersion,
+				FileReference: testutils.CreateFileReference(1, 1, 1, 1),
+			},
+		},
+		{
+			name: "ref is empty",
+			args: args{
+				item: gitlabModels.IncludeItem{
+					File:          ".gitlab-ci.yml",
+					Project:       "group/subgroup/project",
+					Ref:           "",
+					FileReference: testutils.CreateFileReference(1, 1, 1, 1),
+				},
+			},
+			want: &models.Import{
+				Source: &models.ImportSource{
+					Type:         models.SourceTypeRemote,
+					Path:         utils.GetPtr(".gitlab-ci.yml"),
+					SCM:          consts.GitLabPlatform,
+					Repository:   utils.GetPtr("subgroup/project"),
+					Organization: utils.GetPtr("group"),
+				},
+				FileReference: testutils.CreateFileReference(1, 1, 1, 1),
+			},
+		},
+		{
+			name: "File is not empty and project is invalid",
+			args: args{
+				item: gitlabModels.IncludeItem{
+					File:          ".gitlab-ci.yml",
+					Project:       "invalid",
+					Ref:           "master",
+					FileReference: testutils.CreateFileReference(1, 1, 1, 1),
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "Template is empty",
+			args: args{
+				item: gitlabModels.IncludeItem{
+					Template:      "",
+					FileReference: testutils.CreateFileReference(1, 1, 1, 1),
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "Regular template",
+			args: args{
+				item: gitlabModels.IncludeItem{
+					Template:      "Android.gitlab-ci.yml",
+					FileReference: testutils.CreateFileReference(1, 1, 1, 1),
+				},
+			},
+			want: &models.Import{
+				Source: &models.ImportSource{
+					Type:         models.SourceTypeRemote,
+					Path:         utils.GetPtr("lib/gitlab/ci/templates/Android.gitlab-ci.yml"),
+					SCM:          consts.GitLabPlatform,
+					Repository:   utils.GetPtr("gitlab"),
+					Organization: utils.GetPtr("gitlab-org"),
+				},
+				Version:       utils.GetPtr("master"),
+				VersionType:   models.BranchVersion,
+				FileReference: testutils.CreateFileReference(1, 1, 1, 1),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseIncludeItem(tt.args.item)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_parseImports(t *testing.T) {
+	type args struct {
+		include *gitlabModels.Include
+	}
+	tests := []struct {
+		name string
+		args args
+		want []*models.Import
+	}{
+		{
+			name: "Include is nil",
+			args: args{
+				include: nil,
+			},
+			want: nil,
+		},
+		{
+			name: "Include is empty",
+			args: args{
+				include: &gitlabModels.Include{},
+			},
+			want: []*models.Import{},
+		},
+		{
+			name: "Include all type of imports",
+			args: args{
+				include: &gitlabModels.Include{
+					{
+						Local:         ".gitlab-ci.yml",
+						FileReference: testutils.CreateFileReference(1, 1, 1, 1),
+					},
+					{
+						Remote:        "https://gitlab.com/group/subgroup/project/-/raw/master/.gitlab-ci.yml",
+						FileReference: testutils.CreateFileReference(1, 1, 1, 1),
+					},
+					{
+						File:          ".gitlab-ci.yml",
+						Project:       "group/subgroup/project",
+						Ref:           "master",
+						FileReference: testutils.CreateFileReference(1, 1, 1, 1),
+					},
+					{
+						Template:      "Android.gitlab-ci.yml",
+						FileReference: testutils.CreateFileReference(1, 1, 1, 1),
+					},
+				},
+			},
+			want: []*models.Import{
+				{
+					Source: &models.ImportSource{
+						Type: models.SourceTypeLocal,
+						Path: utils.GetPtr(".gitlab-ci.yml"),
+						SCM:  consts.GitLabPlatform,
+					},
+					FileReference: testutils.CreateFileReference(1, 1, 1, 1),
+				},
+				{
+					Source: &models.ImportSource{
+						Type:         models.SourceTypeRemote,
+						Path:         utils.GetPtr(".gitlab-ci.yml"),
+						SCM:          consts.GitLabPlatform,
+						Repository:   utils.GetPtr("subgroup/project"),
+						Organization: utils.GetPtr("group"),
+					},
+					Version:       utils.GetPtr("master"),
+					VersionType:   models.BranchVersion,
+					FileReference: testutils.CreateFileReference(1, 1, 1, 1),
+				},
+				{
+					Source: &models.ImportSource{
+						Type:         models.SourceTypeRemote,
+						Path:         utils.GetPtr(".gitlab-ci.yml"),
+						SCM:          consts.GitLabPlatform,
+						Repository:   utils.GetPtr("subgroup/project"),
+						Organization: utils.GetPtr("group"),
+					},
+					FileReference: testutils.CreateFileReference(1, 1, 1, 1),
+					Version:       utils.GetPtr("master"),
+					VersionType:   models.BranchVersion,
+				},
+				{
+					Source: &models.ImportSource{
+						Type:         models.SourceTypeRemote,
+						Path:         utils.GetPtr("lib/gitlab/ci/templates/Android.gitlab-ci.yml"),
+						SCM:          consts.GitLabPlatform,
+						Repository:   utils.GetPtr("gitlab"),
+						Organization: utils.GetPtr("gitlab-org"),
+					},
+					FileReference: testutils.CreateFileReference(1, 1, 1, 1),
+					Version:       utils.GetPtr("master"),
+					VersionType:   models.BranchVersion,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseImports(tt.args.include)
+			assert.EqualValues(t, tt.want, got)
 		})
 	}
 }

--- a/pkg/parsers/gitlab/imports_test.go
+++ b/pkg/parsers/gitlab/imports_test.go
@@ -114,7 +114,7 @@ func Test_parseRemoteImport(t *testing.T) {
 				},
 				FileReference: testutils.CreateFileReference(1, 1, 1, 1),
 				Version:       utils.GetPtr(""),
-				VersionType:   models.BranchVersion,
+				VersionType:   models.None,
 			},
 		},
 	}
@@ -395,7 +395,7 @@ func Test_parseIncludeItem(t *testing.T) {
 					Organization: utils.GetPtr(""),
 				},
 				Version:       utils.GetPtr(""),
-				VersionType:   models.BranchVersion,
+				VersionType:   models.None,
 				FileReference: testutils.CreateFileReference(1, 1, 1, 1),
 			},
 		},
@@ -537,13 +537,13 @@ func Test_parseImports(t *testing.T) {
 						FileReference: testutils.CreateFileReference(1, 1, 1, 1),
 					},
 					{
-						Remote:        "https://gitlab.com/group/subgroup/project/-/raw/master/.gitlab-ci.yml",
+						Remote:        "https://gitlab.com/group/subgroup/project/-/raw/f7b05602eb1bf22dc808838622c5d8d00b39d473/.gitlab-ci.yml",
 						FileReference: testutils.CreateFileReference(1, 1, 1, 1),
 					},
 					{
 						File:          ".gitlab-ci.yml",
 						Project:       "group/subgroup/project",
-						Ref:           "master",
+						Ref:           "v1",
 						FileReference: testutils.CreateFileReference(1, 1, 1, 1),
 					},
 					{
@@ -569,8 +569,8 @@ func Test_parseImports(t *testing.T) {
 						Repository:   utils.GetPtr("subgroup/project"),
 						Organization: utils.GetPtr("group"),
 					},
-					Version:       utils.GetPtr("master"),
-					VersionType:   models.BranchVersion,
+					Version:       utils.GetPtr("f7b05602eb1bf22dc808838622c5d8d00b39d473"),
+					VersionType:   models.CommitSHA,
 					FileReference: testutils.CreateFileReference(1, 1, 1, 1),
 				},
 				{
@@ -582,8 +582,8 @@ func Test_parseImports(t *testing.T) {
 						Organization: utils.GetPtr("group"),
 					},
 					FileReference: testutils.CreateFileReference(1, 1, 1, 1),
-					Version:       utils.GetPtr("master"),
-					VersionType:   models.BranchVersion,
+					Version:       utils.GetPtr("v1"),
+					VersionType:   models.TagVersion,
 				},
 				{
 					Source: &models.ImportSource{

--- a/pkg/parsers/utils/ref.go
+++ b/pkg/parsers/utils/ref.go
@@ -1,0 +1,28 @@
+package utils
+
+import (
+	"regexp"
+
+	"github.com/argonsecurity/pipeline-parser/pkg/models"
+)
+
+var (
+	sha1Regex   = regexp.MustCompile(`[0-9a-fA-F]{40}`)
+	semverRegex = regexp.MustCompile(`v?([0-9]+)(\.[0-9]+)?(\.[0-9]+)?(-([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?(\+([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?`)
+)
+
+func DetectVersionType(version string) models.VersionType {
+	versionType := models.None
+
+	if version != "" {
+		if sha1Regex.MatchString(version) {
+			versionType = models.CommitSHA
+		} else if semverRegex.MatchString(version) {
+			versionType = models.TagVersion
+		} else {
+			versionType = models.BranchVersion
+		}
+	}
+
+	return versionType
+}

--- a/pkg/parsers/utils/ref_test.go
+++ b/pkg/parsers/utils/ref_test.go
@@ -1,0 +1,55 @@
+package utils
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/argonsecurity/pipeline-parser/pkg/models"
+)
+
+func TestDetectVersionType(t *testing.T) {
+	type args struct {
+		version string
+	}
+	tests := []struct {
+		name string
+		args args
+		want models.VersionType
+	}{
+		{
+			name: "Empty version",
+			args: args{
+				version: "",
+			},
+			want: models.None,
+		},
+		{
+			name: "Commit SHA",
+			args: args{
+				version: "1234567890123456789012345678901234567890",
+			},
+			want: models.CommitSHA,
+		},
+		{
+			name: "Tag version",
+			args: args{
+				version: "v1.2.3",
+			},
+			want: models.TagVersion,
+		},
+		{
+			name: "Branch version",
+			args: args{
+				version: "master",
+			},
+			want: models.BranchVersion,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DetectVersionType(tt.args.version); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("DetectVersionType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/utils/http.go
+++ b/pkg/utils/http.go
@@ -1,0 +1,17 @@
+package utils
+
+import (
+	"fmt"
+
+	"github.com/argonsecurity/pipeline-parser/pkg/models"
+	"github.com/imroc/req/v3"
+)
+
+func GetHttpClient(credentials *models.Credentials) *req.Client {
+	client := req.C()
+	if credentials == nil {
+		return client
+	}
+
+	return client.SetCommonHeader("Authorization", fmt.Sprintf("token %s", credentials.Token))
+}

--- a/test/blackbox/gitlab_test.go
+++ b/test/blackbox/gitlab_test.go
@@ -729,7 +729,7 @@ func TestGitLab(t *testing.T) {
 							Repository:   utils.GetPtr(""),
 						},
 						Version:       utils.GetPtr(""),
-						VersionType:   models.BranchVersion,
+						VersionType:   models.None,
 						FileReference: testutils.CreateFileReference(1, 10, 1, 41),
 					},
 				},

--- a/test/blackbox/gitlab_test.go
+++ b/test/blackbox/gitlab_test.go
@@ -716,6 +716,27 @@ func TestGitLab(t *testing.T) {
 				},
 			}),
 		},
+		{
+			Filename: "invalid-import.yaml",
+			Expected: &models.Pipeline{
+				Imports: []*models.Import{
+					{
+						Source: &models.ImportSource{
+							SCM:          consts.GitLabPlatform,
+							Type:         models.SourceTypeRemote,
+							Path:         utils.GetPtr(""),
+							Organization: utils.GetPtr(""),
+							Repository:   utils.GetPtr(""),
+						},
+						Version:       utils.GetPtr(""),
+						VersionType:   models.BranchVersion,
+						FileReference: testutils.CreateFileReference(1, 10, 1, 41),
+					},
+				},
+				Jobs:     []*models.Job{},
+				Defaults: &models.Defaults{},
+			},
+		},
 	}
 
 	executeTestCases(t, testCases, "gitlab", consts.GitLabPlatform)

--- a/test/blackbox/utils.go
+++ b/test/blackbox/utils.go
@@ -1,21 +1,22 @@
 package blackbox
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"sort"
 	"testing"
 
 	githubEnhancer "github.com/argonsecurity/pipeline-parser/pkg/enhancers/github"
+	gitlabEnhancer "github.com/argonsecurity/pipeline-parser/pkg/enhancers/gitlab"
 	"github.com/argonsecurity/pipeline-parser/pkg/handler"
 	"github.com/argonsecurity/pipeline-parser/pkg/models"
 	"github.com/go-test/deep"
 )
 
 func readFile(filename string) []byte {
-	b, _ := ioutil.ReadFile(filename)
+	b, _ := os.ReadFile(filename)
 	return b
 }
 
@@ -25,6 +26,7 @@ func executeTestCases(t *testing.T, testCases []TestCase, folder string, platfor
 			h := http.FileServer(http.Dir(testCase.TestdataDir))
 			ts := httptest.NewServer(h)
 			githubEnhancer.GithubBaseURL = ts.URL
+			gitlabEnhancer.GITLAB_BASE_URL = ts.URL
 		}
 
 		buf := readFile(filepath.Join("../fixtures", folder, testCase.Filename))
@@ -41,15 +43,7 @@ func executeTestCases(t *testing.T, testCases []TestCase, folder string, platfor
 			continue
 		}
 
-		if pipeline.Jobs != nil {
-			pipeline.Jobs = SortJobs(pipeline.Jobs)
-		}
-		if pipeline.Triggers != nil {
-			pipeline.Triggers = &models.Triggers{
-				Triggers:      SortTriggers(pipeline.Triggers.Triggers),
-				FileReference: pipeline.Triggers.FileReference,
-			}
-		}
+		pipeline = SortPipeline(pipeline)
 
 		if diffs := deep.Equal(pipeline, testCase.Expected); diffs != nil {
 			t.Errorf("there are %d differences in file %s", len(diffs), testCase.Filename)
@@ -58,6 +52,25 @@ func executeTestCases(t *testing.T, testCases []TestCase, folder string, platfor
 			}
 		}
 	}
+}
+
+func SortPipeline(pipeline *models.Pipeline) *models.Pipeline {
+	if pipeline.Jobs != nil {
+		pipeline.Jobs = SortJobs(pipeline.Jobs)
+	}
+	if pipeline.Triggers != nil {
+		pipeline.Triggers = &models.Triggers{
+			Triggers:      SortTriggers(pipeline.Triggers.Triggers),
+			FileReference: pipeline.Triggers.FileReference,
+		}
+	}
+
+	for _, importData := range pipeline.Imports {
+		if importData.Pipeline != nil {
+			importData.Pipeline = SortPipeline(importData.Pipeline)
+		}
+	}
+	return pipeline
 }
 
 func SortJobs(jobs []*models.Job) []*models.Job {

--- a/test/blackbox/utils.go
+++ b/test/blackbox/utils.go
@@ -25,7 +25,7 @@ func executeTestCases(t *testing.T, testCases []TestCase, folder string, platfor
 		if testCase.TestdataDir != "" {
 			h := http.FileServer(http.Dir(testCase.TestdataDir))
 			ts := httptest.NewServer(h)
-			githubEnhancer.GithubBaseURL = ts.URL
+			githubEnhancer.GITHUB_BASE_URL = ts.URL
 			gitlabEnhancer.GITLAB_BASE_URL = ts.URL
 		}
 

--- a/test/fixtures/gitlab/baserow.yaml
+++ b/test/fixtures/gitlab/baserow.yaml
@@ -175,8 +175,6 @@
 #       re-use on master knowing they are safe.
 #
 
-include: "/.gitlab/ci_includes/jobs.yml"
-
 stages:
   - build
   - test
@@ -228,4 +226,3 @@ build-ci-util-image:
     matrix:
       - key1: [value1, value2]
       - key2: value
-

--- a/test/fixtures/gitlab/include-local.yaml
+++ b/test/fixtures/gitlab/include-local.yaml
@@ -1,0 +1,1 @@
+include: /test/fixtures/gitlab/gradle.yaml

--- a/test/fixtures/gitlab/include-local.yaml
+++ b/test/fixtures/gitlab/include-local.yaml
@@ -1,1 +1,1 @@
-include: /test/fixtures/gitlab/gradle.yaml
+include: /../../test/fixtures/gitlab/gradle.yaml

--- a/test/fixtures/gitlab/include-multiple.yaml
+++ b/test/fixtures/gitlab/include-multiple.yaml
@@ -1,7 +1,7 @@
 include:
-  - file: /lib/gitlab/ci/templates/Gradle.gitlab-ci.yml
+  - file: /imported.yaml
     project: gitlab-org/gitlab
     ref: master
-  - https://gitlab.com/gitlab-org/gitlab/-/raw/master/lib/gitlab/ci/templates/Gradle.gitlab-ci.yml
-  - /test/fixtures/gitlab/gradle.yaml
+  - https://gitlab.com/gitlab-org/gitlab/-/raw/master/imported.yaml
+  - /../../test/fixtures/gitlab/gradle.yaml
   - template: Android.gitlab-ci.yml

--- a/test/fixtures/gitlab/include-multiple.yaml
+++ b/test/fixtures/gitlab/include-multiple.yaml
@@ -1,0 +1,6 @@
+include:
+  - file: /lib/gitlab/ci/templates/Gradle.gitlab-ci.yml
+    project: gitlab-org/gitlab
+    ref: master
+  - https://gitlab.com/gitlab-org/gitlab/-/raw/master/lib/gitlab/ci/templates/Gradle.gitlab-ci.yml
+  - /test/fixtures/gitlab/gradle.yaml

--- a/test/fixtures/gitlab/include-multiple.yaml
+++ b/test/fixtures/gitlab/include-multiple.yaml
@@ -4,3 +4,4 @@ include:
     ref: master
   - https://gitlab.com/gitlab-org/gitlab/-/raw/master/lib/gitlab/ci/templates/Gradle.gitlab-ci.yml
   - /test/fixtures/gitlab/gradle.yaml
+  - template: Android.gitlab-ci.yml

--- a/test/fixtures/gitlab/include-remote.yaml
+++ b/test/fixtures/gitlab/include-remote.yaml
@@ -1,0 +1,1 @@
+include: https://gitlab.com/gitlab-org/gitlab/-/raw/master/lib/gitlab/ci/templates/Gradle.gitlab-ci.yml

--- a/test/fixtures/gitlab/include-remote.yaml
+++ b/test/fixtures/gitlab/include-remote.yaml
@@ -1,1 +1,1 @@
-include: https://gitlab.com/gitlab-org/gitlab/-/raw/master/lib/gitlab/ci/templates/Gradle.gitlab-ci.yml
+include: https://gitlab.com/gitlab-org/gitlab/-/raw/master/imported.yaml

--- a/test/fixtures/gitlab/invalid-import.yaml
+++ b/test/fixtures/gitlab/invalid-import.yaml
@@ -1,0 +1,1 @@
+include: https://gitlab.com/invalid.yaml

--- a/test/fixtures/gitlab/terraform.yaml
+++ b/test/fixtures/gitlab/terraform.yaml
@@ -3,10 +3,6 @@
 # This specific template is located at:
 # https://gitlab.com/gitlab-org/gitlab/-/blob/master/lib/gitlab/ci/templates/Terraform.latest.gitlab-ci.yml
 
-include:
-  - template: Terraform/Base.latest.gitlab-ci.yml # https://gitlab.com/gitlab-org/gitlab/blob/master/lib/gitlab/ci/templates/Terraform/Base.latest.gitlab-ci.yml
-  - template: Jobs/SAST-IaC.latest.gitlab-ci.yml
-
 stages:
   - validate
   - test

--- a/test/fixtures/gitlab/testdata/gitlab-org/gitlab/-/raw/master/imported.yaml
+++ b/test/fixtures/gitlab/testdata/gitlab-org/gitlab/-/raw/master/imported.yaml
@@ -1,0 +1,35 @@
+# To contribute improvements to CI/CD templates, please follow the Development guide at:
+# https://docs.gitlab.com/ee/development/cicd/templates.html
+# This specific template is located at:
+# https://gitlab.com/gitlab-org/gitlab/-/blob/master/lib/gitlab/ci/templates/Gradle.gitlab-ci.yml
+
+# This is the Gradle build system for JVM applications
+# https://gradle.org/
+# https://github.com/gradle/gradle
+
+image: gradle:alpine
+
+# Disable the Gradle daemon for Continuous Integration servers as correctness
+# is usually a priority over speed in CI environments. Using a fresh
+# runtime for each build is more reliable since the runtime is completely
+# isolated from any previous builds.
+variables:
+  GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+
+before_script:
+  - GRADLE_USER_HOME="$(pwd)/.gradle"
+  - export GRADLE_USER_HOME
+
+build:
+  stage: build
+  script: gradle --build-cache assemble
+  cache:
+    key: "$CI_COMMIT_REF_NAME"
+    policy: push
+    paths:
+      - build
+      - .gradle
+
+test:
+  stage: test
+  script: gradle check

--- a/test/fixtures/gitlab/testdata/gitlab-org/gitlab/-/raw/master/lib/gitlab/ci/templates/Android.gitlab-ci.yml
+++ b/test/fixtures/gitlab/testdata/gitlab-org/gitlab/-/raw/master/lib/gitlab/ci/templates/Android.gitlab-ci.yml
@@ -1,0 +1,35 @@
+# To contribute improvements to CI/CD templates, please follow the Development guide at:
+# https://docs.gitlab.com/ee/development/cicd/templates.html
+# This specific template is located at:
+# https://gitlab.com/gitlab-org/gitlab/-/blob/master/lib/gitlab/ci/templates/Gradle.gitlab-ci.yml
+
+# This is the Gradle build system for JVM applications
+# https://gradle.org/
+# https://github.com/gradle/gradle
+
+image: gradle:alpine
+
+# Disable the Gradle daemon for Continuous Integration servers as correctness
+# is usually a priority over speed in CI environments. Using a fresh
+# runtime for each build is more reliable since the runtime is completely
+# isolated from any previous builds.
+variables:
+  GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+
+before_script:
+  - GRADLE_USER_HOME="$(pwd)/.gradle"
+  - export GRADLE_USER_HOME
+
+build:
+  stage: build
+  script: gradle --build-cache assemble
+  cache:
+    key: "$CI_COMMIT_REF_NAME"
+    policy: push
+    paths:
+      - build
+      - .gradle
+
+test:
+  stage: test
+  script: gradle check


### PR DESCRIPTION
## Description
GitLab now supports imported pipelines (using the `include:` keyword)


## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/argonsecurity/pipeline-parser/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've followed the [conventions](https://github.com/argonsecurity/pipeline-parser/blob/main/CONTRIBUTING.md#pull-requests) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [readme](https://github.com/argonsecurity/pipeline-parser/blob/main/README.md) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).